### PR TITLE
Refactor repositories and ImdbDatasetImporter

### DIFF
--- a/src/IMDb.Core/Repositories/INameBasicsRepository.cs
+++ b/src/IMDb.Core/Repositories/INameBasicsRepository.cs
@@ -4,13 +4,8 @@ using IMDb.Core.Models;
 
 namespace IMDb.Core.Repositories
 {
-    public interface INameBasicsRepository
+    public interface INameBasicsRepository : IRepository<NameBasics>
     {
-        Task Add(NameBasics model);
-        Task Update(NameBasics model);
-        Task Delete(NameBasics model);
-        void BulkSync(IEnumerable<NameBasics> models);
-
         Task<NameBasics> FindByNConst(string nconst);
 
         Task<IReadOnlyList<NameBasics>> FindByPrimaryName(int page, string primaryName);

--- a/src/IMDb.Core/Repositories/IRepository.cs
+++ b/src/IMDb.Core/Repositories/IRepository.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using IMDb.Core.Models;
+
+namespace IMDb.Core.Repositories
+{
+    public interface IRepository<T>
+    {
+        Task Add(T model);
+        Task Update(T model);
+        Task Delete(T model);
+        void BulkSync(IEnumerable<T> models);
+    }
+}

--- a/src/IMDb.Core/Repositories/ITitleAKAsRepository.cs
+++ b/src/IMDb.Core/Repositories/ITitleAKAsRepository.cs
@@ -4,13 +4,8 @@ using IMDb.Core.Models;
 
 namespace IMDb.Core.Repositories
 {
-    public interface ITitleAKAsRepository
+    public interface ITitleAKAsRepository : IRepository<TitleAKAs>
     {
-        Task Add(TitleAKAs model);
-        Task Update(TitleAKAs model);
-        Task Delete(TitleAKAs model);
-        void BulkSync(IEnumerable<TitleAKAs> models);
-
         Task<TitleAKAs> FindByFullInfo(string tconst, int ordering);
         Task<IReadOnlyList<TitleAKAs>> FindByTitleId(string tconst);
 

--- a/src/IMDb.Core/Repositories/ITitleBasicsRepository.cs
+++ b/src/IMDb.Core/Repositories/ITitleBasicsRepository.cs
@@ -4,13 +4,8 @@ using IMDb.Core.Models;
 
 namespace IMDb.Core.Repositories
 {
-    public interface ITitleBasicsRepository
+    public interface ITitleBasicsRepository : IRepository<TitleBasics>
     {
-        Task Add(TitleBasics model);
-        Task Update(TitleBasics model);
-        Task Delete(TitleBasics model);
-        void BulkSync(IEnumerable<TitleBasics> models);
-
         Task<TitleBasics> FindByTConst(string tconst);
 
         Task<IReadOnlyList<TitleBasics>> FindByTitleType(int page, string type);

--- a/src/IMDb.Core/Repositories/ITitleCrewRepository.cs
+++ b/src/IMDb.Core/Repositories/ITitleCrewRepository.cs
@@ -4,13 +4,8 @@ using IMDb.Core.Models;
 
 namespace IMDb.Core.Repositories
 {
-    public interface ITitleCrewRepository
+    public interface ITitleCrewRepository : IRepository<TitleCrew>
     {
-        Task Add(TitleCrew model);
-        Task Update(TitleCrew model);
-        Task Delete(TitleCrew model);
-        void BulkSync(IEnumerable<TitleCrew> models);
-
         Task<TitleCrew> FindByTConst(string tconst);
 
         Task<IReadOnlyList<TitleCrew>> FindByDirectors(int page, params string[] directorsNconsts);

--- a/src/IMDb.Core/Repositories/ITitleEpisodeRepository.cs
+++ b/src/IMDb.Core/Repositories/ITitleEpisodeRepository.cs
@@ -4,13 +4,8 @@ using IMDb.Core.Models;
 
 namespace IMDb.Core.Repositories
 {
-    public interface ITitleEpisodeRepository
+    public interface ITitleEpisodeRepository : IRepository<TitleEpisode>
     {
-        Task Add(TitleEpisode model);
-        Task Update(TitleEpisode model);
-        Task Delete(TitleEpisode model);
-        void BulkSync(IEnumerable<TitleEpisode> models);
-
         Task<TitleEpisode> FindByTConst(string tconst);
         Task<TitleEpisode> FindByFullInfo(string parentTconst, int? season, int? episode);
 

--- a/src/IMDb.Core/Repositories/ITitlePrincipalsRepository.cs
+++ b/src/IMDb.Core/Repositories/ITitlePrincipalsRepository.cs
@@ -4,13 +4,8 @@ using IMDb.Core.Models;
 
 namespace IMDb.Core.Repositories
 {
-    public interface ITitlePrincipalsRepository
+    public interface ITitlePrincipalsRepository : IRepository<TitlePrincipals>
     {
-        Task Add(TitlePrincipals model);
-        Task Update(TitlePrincipals model);
-        Task Delete(TitlePrincipals model);
-        void BulkSync(IEnumerable<TitlePrincipals> models);
-
         Task<IReadOnlyList<TitlePrincipals>> FindByTitle(string tconst);
         Task<TitlePrincipals> FindByFullInfo(string tconst, string nconst);
 

--- a/src/IMDb.Core/Repositories/ITitleRatingsRepository.cs
+++ b/src/IMDb.Core/Repositories/ITitleRatingsRepository.cs
@@ -4,13 +4,8 @@ using IMDb.Core.Models;
 
 namespace IMDb.Core.Repositories
 {
-    public interface ITitleRatingsRepository
+    public interface ITitleRatingsRepository : IRepository<TitleRatings>
     {
-        Task Add(TitleRatings model);
-        Task Update(TitleRatings model);
-        Task Delete(TitleRatings model);
-        void BulkSync(IEnumerable<TitleRatings> models);
-
         Task<TitleRatings> FindByTitle(string tconst);
 
         Task<IReadOnlyList<TitleRatings>> FindByRating(int page, decimal rating, decimal deltaAllowed = 0);

--- a/src/IMDb.Importer/ImdbDatasetImporter.cs
+++ b/src/IMDb.Importer/ImdbDatasetImporter.cs
@@ -69,13 +69,13 @@ namespace IMDb.Importer
         {
             var tasks = new List<Task>
             {
-                DownloadAndImportNameBasics(),
-                DownloadAndImportTitleAKAs(),
-                DownloadAndImportTitleBasics(),
-                DownloadAndImportTitleCrew(),
-                DownloadAndImportTitleEpisode(),
-                DownloadAndImportTitlePrincipals(),
-                DownloadAndImportTitleRatings()
+                DownloadAndImportType(_nameBasicsRepository),
+                DownloadAndImportType(_titleAKAsRepository),
+                DownloadAndImportType(_titleBasicsRepository),
+                DownloadAndImportType(_titleCrewRepository),
+                DownloadAndImportType(_titleEpisodeRepository),
+                DownloadAndImportType(_titlePrincipalsRepository),
+                DownloadAndImportType(_titleRatingsRepository)
             };
 
             await Task.WhenAll(tasks);
@@ -110,43 +110,6 @@ namespace IMDb.Importer
             return fileName;
         }
 
-        #region Individual Dataset Import Functions
-
-        private async Task DownloadAndImportNameBasics()
-        {
-            await DownloadAndImportType<NameBasics>(_nameBasicsRepository);
-        }
-
-        private async Task DownloadAndImportTitleAKAs()
-        {
-            await DownloadAndImportType<TitleAKAs>(_titleAKAsRepository);
-        }
-
-        private async Task DownloadAndImportTitleBasics()
-        {
-            await DownloadAndImportType<TitleBasics>(_titleBasicsRepository);
-        }
-
-        private async Task DownloadAndImportTitleCrew()
-        {
-            await DownloadAndImportType<TitleCrew>(_titleCrewRepository);
-        }
-
-        private async Task DownloadAndImportTitleEpisode()
-        {
-            await DownloadAndImportType<TitleEpisode>(_titleEpisodeRepository);
-        }
-
-        private async Task DownloadAndImportTitlePrincipals()
-        {
-            await DownloadAndImportType<TitlePrincipals>(_titlePrincipalsRepository);
-        }
-
-        private async Task DownloadAndImportTitleRatings()
-        {
-            await DownloadAndImportType<TitleRatings>(_titleRatingsRepository);
-        }
-
         private async Task DownloadAndImportType<T>(AbstractRepository<T> repository, string outputFileName = nameof(T)) where T : class
         {
             var file = await DownloadDataset(repository.Url, outputFileName);
@@ -159,7 +122,5 @@ namespace IMDb.Importer
                 repository.BulkSync(batch);
             }
         }
-
-        #endregion
     }
 }

--- a/src/IMDb.Importer/ImdbDatasetImporter.cs
+++ b/src/IMDb.Importer/ImdbDatasetImporter.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using IMDb.Core.Models;
 using IMDb.Core.Parsers;
+using IMDb.Core.Repositories;
 using IMDb.Infrastructure.Extensions;
 using IMDb.Infrastructure.Repositories;
 using Marten;
@@ -125,8 +126,10 @@ namespace IMDb.Importer
             return fileName;
         }
 
-        private async Task DownloadAndImportType<T>(AbstractRepository<T> repository, string outputFileName = nameof(T)) where T : class
+        private async Task DownloadAndImportType<T>(IRepository<T> repository, string outputFileName = null) where T : class
         {
+            outputFileName ??= typeof(T).Name;
+
             var file = await DownloadDataset(_repositoryUrls[typeof(T)], outputFileName);
             await using var fileStream = File.OpenRead(file);
 

--- a/src/IMDb.Importer/ImdbDatasetImporter.cs
+++ b/src/IMDb.Importer/ImdbDatasetImporter.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using IMDb.Core.Models;
 using IMDb.Core.Parsers;
-using IMDb.Core.Repositories;
 using IMDb.Infrastructure.Extensions;
 using IMDb.Infrastructure.Repositories;
 using Marten;
@@ -115,43 +114,42 @@ namespace IMDb.Importer
 
         private async Task DownloadAndImportNameBasics()
         {
-            await DownloadAndImportType<NameBasics>("https://datasets.imdbws.com/name.basics.tsv.gz", _nameBasicsRepository);
+            await DownloadAndImportType<NameBasics>(_nameBasicsRepository);
         }
-
 
         private async Task DownloadAndImportTitleAKAs()
         {
-            await DownloadAndImportType<TitleAKAs>("https://datasets.imdbws.com/title.akas.tsv.gz", _titleAKAsRepository);
+            await DownloadAndImportType<TitleAKAs>(_titleAKAsRepository);
         }
 
         private async Task DownloadAndImportTitleBasics()
         {
-            await DownloadAndImportType<TitleBasics>("https://datasets.imdbws.com/title.basics.tsv.gz", _titleBasicsRepository);
+            await DownloadAndImportType<TitleBasics>(_titleBasicsRepository);
         }
 
         private async Task DownloadAndImportTitleCrew()
         {
-            await DownloadAndImportType<TitleCrew>("https://datasets.imdbws.com/title.crew.tsv.gz", _titleCrewRepository);
+            await DownloadAndImportType<TitleCrew>(_titleCrewRepository);
         }
 
         private async Task DownloadAndImportTitleEpisode()
         {
-            await DownloadAndImportType<TitleEpisode>("https://datasets.imdbws.com/title.episode.tsv.gz", _titleEpisodeRepository);
+            await DownloadAndImportType<TitleEpisode>(_titleEpisodeRepository);
         }
 
         private async Task DownloadAndImportTitlePrincipals()
         {
-            await DownloadAndImportType<TitlePrincipals>("https://datasets.imdbws.com/title.principals.tsv.gz", _titlePrincipalsRepository);
+            await DownloadAndImportType<TitlePrincipals>(_titlePrincipalsRepository);
         }
 
         private async Task DownloadAndImportTitleRatings()
         {
-            await DownloadAndImportType<TitleRatings>("https://datasets.imdbws.com/title.ratings.tsv.gz", _titleRatingsRepository);
+            await DownloadAndImportType<TitleRatings>(_titleRatingsRepository);
         }
 
-        private async Task DownloadAndImportType<T>(string url, IRepository<T> repository, string outputFileName = nameof(T)) where T : class
+        private async Task DownloadAndImportType<T>(AbstractRepository<T> repository, string outputFileName = nameof(T)) where T : class
         {
-            var file = await DownloadDataset(url, outputFileName);
+            var file = await DownloadDataset(repository.Url, outputFileName);
             await using var fileStream = File.OpenRead(file);
 
             var batches = _datasetParser.Parse<T>(fileStream);

--- a/src/IMDb.Importer/ImdbDatasetImporter.cs
+++ b/src/IMDb.Importer/ImdbDatasetImporter.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using IMDb.Core.Models;
 using IMDb.Core.Parsers;
+using IMDb.Core.Repositories;
 using IMDb.Infrastructure.Extensions;
 using IMDb.Infrastructure.Repositories;
 using Marten;
@@ -110,99 +111,54 @@ namespace IMDb.Importer
             return fileName;
         }
 
-        // These could be refactored to have the shared logic in one spot, but its not that much code, so I don't mind for now
-
         #region Individual Dataset Import Functions
 
         private async Task DownloadAndImportNameBasics()
         {
-            var file = await DownloadDataset("https://datasets.imdbws.com/name.basics.tsv.gz", nameof(NameBasics));
-            await using var fileStream = File.OpenRead(file);
-
-            var batches = _datasetParser.Parse<NameBasics>(fileStream);
-
-            await foreach (var batch in batches)
-            {
-                _nameBasicsRepository.BulkSync(batch);
-            }
+            await DownloadAndImportType<NameBasics>("https://datasets.imdbws.com/name.basics.tsv.gz", _nameBasicsRepository);
         }
+
 
         private async Task DownloadAndImportTitleAKAs()
         {
-            var file = await DownloadDataset("https://datasets.imdbws.com/title.akas.tsv.gz", nameof(TitleAKAs));
-            await using var fileStream = File.OpenRead(file);
-
-            var batches = _datasetParser.Parse<TitleAKAs>(fileStream);
-
-            await foreach (var batch in batches)
-            {
-                _titleAKAsRepository.BulkSync(batch);
-            }
+            await DownloadAndImportType<TitleAKAs>("https://datasets.imdbws.com/title.akas.tsv.gz", _titleAKAsRepository);
         }
 
         private async Task DownloadAndImportTitleBasics()
         {
-            var file = await DownloadDataset("https://datasets.imdbws.com/title.basics.tsv.gz", nameof(TitleBasics));
-            await using var fileStream = File.OpenRead(file);
-
-            var batches = _datasetParser.Parse<TitleBasics>(fileStream);
-
-            await foreach (var batch in batches)
-            {
-                _titleBasicsRepository.BulkSync(batch);
-            }
+            await DownloadAndImportType<TitleBasics>("https://datasets.imdbws.com/title.basics.tsv.gz", _titleBasicsRepository);
         }
 
         private async Task DownloadAndImportTitleCrew()
         {
-            var file = await DownloadDataset("https://datasets.imdbws.com/title.crew.tsv.gz", nameof(TitleCrew));
-            await using var fileStream = File.OpenRead(file);
-
-            var batches = _datasetParser.Parse<TitleCrew>(fileStream);
-
-            await foreach (var batch in batches)
-            {
-                _titleCrewRepository.BulkSync(batch);
-            }
+            await DownloadAndImportType<TitleCrew>("https://datasets.imdbws.com/title.crew.tsv.gz", _titleCrewRepository);
         }
 
         private async Task DownloadAndImportTitleEpisode()
         {
-            var file = await DownloadDataset("https://datasets.imdbws.com/title.episode.tsv.gz", nameof(TitleEpisode));
-            await using var fileStream = File.OpenRead(file);
-
-            var batches = _datasetParser.Parse<TitleEpisode>(fileStream);
-
-            await foreach (var batch in batches)
-            {
-                _titleEpisodeRepository.BulkSync(batch);
-            }
+            await DownloadAndImportType<TitleEpisode>("https://datasets.imdbws.com/title.episode.tsv.gz", _titleEpisodeRepository);
         }
 
         private async Task DownloadAndImportTitlePrincipals()
         {
-            var file = await DownloadDataset("https://datasets.imdbws.com/title.principals.tsv.gz",
-                nameof(TitlePrincipals));
-            await using var fileStream = File.OpenRead(file);
-
-            var batches = _datasetParser.Parse<TitlePrincipals>(fileStream);
-
-            await foreach (var batch in batches)
-            {
-                _titlePrincipalsRepository.BulkSync(batch);
-            }
+            await DownloadAndImportType<TitlePrincipals>("https://datasets.imdbws.com/title.principals.tsv.gz", _titlePrincipalsRepository);
         }
 
         private async Task DownloadAndImportTitleRatings()
         {
-            var file = await DownloadDataset("https://datasets.imdbws.com/title.ratings.tsv.gz", nameof(TitleRatings));
+            await DownloadAndImportType<TitleRatings>("https://datasets.imdbws.com/title.ratings.tsv.gz", _titleRatingsRepository);
+        }
+
+        private async Task DownloadAndImportType<T>(string url, IRepository<T> repository, string outputFileName = nameof(T)) where T : class
+        {
+            var file = await DownloadDataset(url, outputFileName);
             await using var fileStream = File.OpenRead(file);
 
-            var batches = _datasetParser.Parse<TitleRatings>(fileStream);
+            var batches = _datasetParser.Parse<T>(fileStream);
 
             await foreach (var batch in batches)
             {
-                _titleRatingsRepository.BulkSync(batch);
+                repository.BulkSync(batch);
             }
         }
 

--- a/src/IMDb.Infrastructure/Repositories/AbstractRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/AbstractRepository.cs
@@ -10,8 +10,6 @@ namespace IMDb.Infrastructure.Repositories
 {
     public abstract class AbstractRepository<T> : IRepository<T>
     {
-        public string Url => GetUrl();
-
         protected readonly IDocumentStore _store;
 
         public AbstractRepository(IDocumentStore store) => _store = store;
@@ -47,7 +45,5 @@ namespace IMDb.Infrastructure.Repositories
         {
             _store.BulkInsert(models.ToArray(), BulkInsertMode.OverwriteExisting);
         }
-
-        protected abstract string GetUrl();
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/AbstractRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/AbstractRepository.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using IMDb.Core.Models;
+using IMDb.Core.Repositories;
+using Marten;
+
+namespace IMDb.Infrastructure.Repositories
+{
+    public abstract class AbstractRepository<T> : IRepository<T>
+    {
+        public string Url
+        {
+            get
+            {
+                return GetUrl();
+            }
+        }
+
+        protected readonly IDocumentStore _store;
+
+        public AbstractRepository(IDocumentStore store) => _store = store;
+
+        public async Task Add(T model)
+        {
+            using var session = _store.DirtyTrackedSession();
+
+            session.Insert(model);
+
+            await session.SaveChangesAsync();
+        }
+
+        public async Task Update(T model)
+        {
+            using var session = _store.DirtyTrackedSession();
+
+            session.Update(model);
+
+            await session.SaveChangesAsync();
+        }
+
+        public async Task Delete(T model)
+        {
+            using var session = _store.DirtyTrackedSession();
+
+            session.Delete(model);
+
+            await session.SaveChangesAsync();
+        }
+
+        public void BulkSync(IEnumerable<T> models)
+        {
+            _store.BulkInsert(models.ToArray(), BulkInsertMode.OverwriteExisting);
+        }
+
+        protected abstract string GetUrl();
+    }
+}

--- a/src/IMDb.Infrastructure/Repositories/AbstractRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/AbstractRepository.cs
@@ -10,13 +10,7 @@ namespace IMDb.Infrastructure.Repositories
 {
     public abstract class AbstractRepository<T> : IRepository<T>
     {
-        public string Url
-        {
-            get
-            {
-                return GetUrl();
-            }
-        }
+        public string Url => GetUrl();
 
         protected readonly IDocumentStore _store;
 

--- a/src/IMDb.Infrastructure/Repositories/NameBasicsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/NameBasicsRepository.cs
@@ -10,7 +10,7 @@ namespace IMDb.Infrastructure.Repositories
 {
     public class NameBasicsRepository : AbstractRepository<NameBasics>, INameBasicsRepository
     {
-        public NameBasicsRepository(IDocumentStore store) : base(store) {}
+        public NameBasicsRepository(IDocumentStore store) : base(store) { }
 
         public async Task<NameBasics> FindByNConst(string nconst)
         {
@@ -80,9 +80,6 @@ namespace IMDb.Infrastructure.Repositories
                 .ToListAsync();
         }
 
-        protected override string GetUrl()
-        {
-            return "https://datasets.imdbws.com/name.basics.tsv.gz";
-        }
+        protected override string GetUrl() => "https://datasets.imdbws.com/name.basics.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/NameBasicsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/NameBasicsRepository.cs
@@ -79,7 +79,5 @@ namespace IMDb.Infrastructure.Repositories
                 .Take(pagination.Take)
                 .ToListAsync();
         }
-
-        protected override string GetUrl() => "https://datasets.imdbws.com/name.basics.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/NameBasicsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/NameBasicsRepository.cs
@@ -8,43 +8,9 @@ using Marten;
 
 namespace IMDb.Infrastructure.Repositories
 {
-    public class NameBasicsRepository : INameBasicsRepository
+    public class NameBasicsRepository : AbstractRepository<NameBasics>, INameBasicsRepository
     {
-        private readonly IDocumentStore _store;
-
-        public NameBasicsRepository(IDocumentStore store) => _store = store;
-
-        public async Task Add(NameBasics model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Insert(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Update(NameBasics model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Update(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Delete(NameBasics model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Delete(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public void BulkSync(IEnumerable<NameBasics> models)
-        {
-            _store.BulkInsert(models.ToArray(), BulkInsertMode.OverwriteExisting);
-        }
+        public NameBasicsRepository(IDocumentStore store) : base(store) {}
 
         public async Task<NameBasics> FindByNConst(string nconst)
         {
@@ -112,6 +78,11 @@ namespace IMDb.Infrastructure.Repositories
                 .Skip(pagination.Skip)
                 .Take(pagination.Take)
                 .ToListAsync();
+        }
+
+        protected override string GetUrl()
+        {
+            return "https://datasets.imdbws.com/name.basics.tsv.gz";
         }
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleAKAsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleAKAsRepository.cs
@@ -100,7 +100,5 @@ namespace IMDb.Infrastructure.Repositories
                 .Take(pagination.Take)
                 .ToListAsync();
         }
-
-        protected override string GetUrl() => "https://datasets.imdbws.com/title.akas.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleAKAsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleAKAsRepository.cs
@@ -8,43 +8,9 @@ using Marten;
 
 namespace IMDb.Infrastructure.Repositories
 {
-    public class TitleAKAsRepository : ITitleAKAsRepository
+    public class TitleAKAsRepository : AbstractRepository<TitleAKAs>, ITitleAKAsRepository
     {
-        private readonly IDocumentStore _store;
-
-        public TitleAKAsRepository(IDocumentStore store) => _store = store;
-
-        public async Task Add(TitleAKAs model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Insert(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Update(TitleAKAs model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Update(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Delete(TitleAKAs model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Delete(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public void BulkSync(IEnumerable<TitleAKAs> models)
-        {
-            _store.BulkInsert(models.ToArray(), BulkInsertMode.OverwriteExisting);
-        }
+        public TitleAKAsRepository(IDocumentStore store) : base(store){}
 
         public async Task<TitleAKAs> FindByFullInfo(string tconst, int ordering)
         {
@@ -52,7 +18,6 @@ namespace IMDb.Infrastructure.Repositories
 
             return await session.Query<TitleAKAs>().SingleAsync(x => x.TitleId == tconst && x.Ordering == ordering);
         }
-
 
         public async Task<IReadOnlyList<TitleAKAs>> FindByTitleId(string tconst)
         {
@@ -134,6 +99,11 @@ namespace IMDb.Infrastructure.Repositories
                 .Skip(pagination.Skip)
                 .Take(pagination.Take)
                 .ToListAsync();
+        }
+
+        protected override string GetUrl()
+        {
+            return "https://datasets.imdbws.com/title.akas.tsv.gz";
         }
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleAKAsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleAKAsRepository.cs
@@ -10,7 +10,7 @@ namespace IMDb.Infrastructure.Repositories
 {
     public class TitleAKAsRepository : AbstractRepository<TitleAKAs>, ITitleAKAsRepository
     {
-        public TitleAKAsRepository(IDocumentStore store) : base(store){}
+        public TitleAKAsRepository(IDocumentStore store) : base(store) { }
 
         public async Task<TitleAKAs> FindByFullInfo(string tconst, int ordering)
         {
@@ -101,9 +101,6 @@ namespace IMDb.Infrastructure.Repositories
                 .ToListAsync();
         }
 
-        protected override string GetUrl()
-        {
-            return "https://datasets.imdbws.com/title.akas.tsv.gz";
-        }
+        protected override string GetUrl() => "https://datasets.imdbws.com/title.akas.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleBasicsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleBasicsRepository.cs
@@ -8,43 +8,9 @@ using Marten;
 
 namespace IMDb.Infrastructure.Repositories
 {
-    public class TitleBasicsRepository : ITitleBasicsRepository
+    public class TitleBasicsRepository : AbstractRepository<TitleBasics>, ITitleBasicsRepository
     {
-        private readonly IDocumentStore _store;
-
-        public TitleBasicsRepository(IDocumentStore store) => _store = store;
-
-        public async Task Add(TitleBasics model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Insert(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Update(TitleBasics model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Update(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Delete(TitleBasics model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Delete(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public void BulkSync(IEnumerable<TitleBasics> models)
-        {
-            _store.BulkInsert(models.ToArray(), BulkInsertMode.OverwriteExisting);
-        }
+        public TitleBasicsRepository(IDocumentStore store) : base(store) {}
 
         public async Task<TitleBasics> FindByTConst(string tconst)
         {
@@ -151,6 +117,11 @@ namespace IMDb.Infrastructure.Repositories
                 .Skip(pagination.Skip)
                 .Take(pagination.Take)
                 .ToListAsync();
+        }
+
+        protected override string GetUrl()
+        {
+            return "https://datasets.imdbws.com/title.basics.tsv.gz";
         }
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleBasicsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleBasicsRepository.cs
@@ -118,7 +118,5 @@ namespace IMDb.Infrastructure.Repositories
                 .Take(pagination.Take)
                 .ToListAsync();
         }
-
-        protected override string GetUrl() => "https://datasets.imdbws.com/title.basics.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleBasicsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleBasicsRepository.cs
@@ -10,7 +10,7 @@ namespace IMDb.Infrastructure.Repositories
 {
     public class TitleBasicsRepository : AbstractRepository<TitleBasics>, ITitleBasicsRepository
     {
-        public TitleBasicsRepository(IDocumentStore store) : base(store) {}
+        public TitleBasicsRepository(IDocumentStore store) : base(store) { }
 
         public async Task<TitleBasics> FindByTConst(string tconst)
         {
@@ -119,9 +119,6 @@ namespace IMDb.Infrastructure.Repositories
                 .ToListAsync();
         }
 
-        protected override string GetUrl()
-        {
-            return "https://datasets.imdbws.com/title.basics.tsv.gz";
-        }
+        protected override string GetUrl() => "https://datasets.imdbws.com/title.basics.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleCrewRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleCrewRepository.cs
@@ -42,9 +42,6 @@ namespace IMDb.Infrastructure.Repositories
                 .ToListAsync();
         }
 
-        protected override string GetUrl()
-        {
-            return "https://datasets.imdbws.com/title.crew.tsv.gz";
-        }
+        protected override string GetUrl() => "https://datasets.imdbws.com/title.crew.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleCrewRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleCrewRepository.cs
@@ -41,7 +41,5 @@ namespace IMDb.Infrastructure.Repositories
                 .Take(pagination.Take)
                 .ToListAsync();
         }
-
-        protected override string GetUrl() => "https://datasets.imdbws.com/title.crew.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleCrewRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleCrewRepository.cs
@@ -7,43 +7,9 @@ using Marten;
 
 namespace IMDb.Infrastructure.Repositories
 {
-    public class TitleCrewRepository : ITitleCrewRepository
+    public class TitleCrewRepository : AbstractRepository<TitleCrew>, ITitleCrewRepository
     {
-        private readonly IDocumentStore _store;
-
-        public TitleCrewRepository(IDocumentStore store) => _store = store;
-
-        public async Task Add(TitleCrew model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Insert(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Update(TitleCrew model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Update(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Delete(TitleCrew model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Delete(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public void BulkSync(IEnumerable<TitleCrew> models)
-        {
-            _store.BulkInsert(models.ToArray(), BulkInsertMode.OverwriteExisting);
-        }
+        public TitleCrewRepository(IDocumentStore store) : base(store) { }
 
         public async Task<TitleCrew> FindByTConst(string tconst)
         {
@@ -74,6 +40,11 @@ namespace IMDb.Infrastructure.Repositories
                 .Skip(pagination.Skip)
                 .Take(pagination.Take)
                 .ToListAsync();
+        }
+
+        protected override string GetUrl()
+        {
+            return "https://datasets.imdbws.com/title.crew.tsv.gz";
         }
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleEpisodeRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleEpisodeRepository.cs
@@ -9,7 +9,7 @@ namespace IMDb.Infrastructure.Repositories
 {
     public class TitleEpisodeRepository : AbstractRepository<TitleEpisode>, ITitleEpisodeRepository
     {
-        public TitleEpisodeRepository(IDocumentStore store) : base(store) {}
+        public TitleEpisodeRepository(IDocumentStore store) : base(store) { }
 
         public async Task<TitleEpisode> FindByTConst(string tconst)
         {
@@ -62,9 +62,6 @@ namespace IMDb.Infrastructure.Repositories
                 .ToListAsync();
         }
 
-        protected override string GetUrl()
-        {
-            return "https://datasets.imdbws.com/title.episode.tsv.gz";
-        }
+        protected override string GetUrl() => "https://datasets.imdbws.com/title.episode.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleEpisodeRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleEpisodeRepository.cs
@@ -61,7 +61,5 @@ namespace IMDb.Infrastructure.Repositories
                 .Take(pagination.Take)
                 .ToListAsync();
         }
-
-        protected override string GetUrl() => "https://datasets.imdbws.com/title.episode.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleEpisodeRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleEpisodeRepository.cs
@@ -7,43 +7,9 @@ using Marten;
 
 namespace IMDb.Infrastructure.Repositories
 {
-    public class TitleEpisodeRepository : ITitleEpisodeRepository
+    public class TitleEpisodeRepository : AbstractRepository<TitleEpisode>, ITitleEpisodeRepository
     {
-        private readonly IDocumentStore _store;
-
-        public TitleEpisodeRepository(IDocumentStore store) => _store = store;
-
-        public async Task Add(TitleEpisode model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Insert(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Update(TitleEpisode model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Update(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Delete(TitleEpisode model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Delete(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public void BulkSync(IEnumerable<TitleEpisode> models)
-        {
-            _store.BulkInsert(models.ToArray(), BulkInsertMode.OverwriteExisting);
-        }
+        public TitleEpisodeRepository(IDocumentStore store) : base(store) {}
 
         public async Task<TitleEpisode> FindByTConst(string tconst)
         {
@@ -94,6 +60,11 @@ namespace IMDb.Infrastructure.Repositories
                 .Skip(pagination.Skip)
                 .Take(pagination.Take)
                 .ToListAsync();
+        }
+
+        protected override string GetUrl()
+        {
+            return "https://datasets.imdbws.com/title.episode.tsv.gz";
         }
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitlePrincipalsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitlePrincipalsRepository.cs
@@ -90,7 +90,5 @@ namespace IMDb.Infrastructure.Repositories
                 .Take(pagination.Take)
                 .ToListAsync();
         }
-
-        protected override string GetUrl() => "https://datasets.imdbws.com/title.principals.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitlePrincipalsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitlePrincipalsRepository.cs
@@ -10,7 +10,7 @@ namespace IMDb.Infrastructure.Repositories
 {
     public class TitlePrincipalsRepository : AbstractRepository<TitlePrincipals>, ITitlePrincipalsRepository
     {
-        public TitlePrincipalsRepository(IDocumentStore store) : base(store) {}
+        public TitlePrincipalsRepository(IDocumentStore store) : base(store) { }
 
         public async Task<IReadOnlyList<TitlePrincipals>> FindByTitle(string tconst)
         {
@@ -91,9 +91,6 @@ namespace IMDb.Infrastructure.Repositories
                 .ToListAsync();
         }
 
-        protected override string GetUrl()
-        {
-            return "https://datasets.imdbws.com/title.principals.tsv.gz";
-        }
+        protected override string GetUrl() => "https://datasets.imdbws.com/title.principals.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitlePrincipalsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitlePrincipalsRepository.cs
@@ -8,43 +8,9 @@ using Marten;
 
 namespace IMDb.Infrastructure.Repositories
 {
-    public class TitlePrincipalsRepository : ITitlePrincipalsRepository
+    public class TitlePrincipalsRepository : AbstractRepository<TitlePrincipals>, ITitlePrincipalsRepository
     {
-        private readonly IDocumentStore _store;
-
-        public TitlePrincipalsRepository(IDocumentStore store) => _store = store;
-
-        public async Task Add(TitlePrincipals model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Insert(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Update(TitlePrincipals model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Update(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Delete(TitlePrincipals model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Delete(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public void BulkSync(IEnumerable<TitlePrincipals> models)
-        {
-            _store.BulkInsert(models.ToArray(), BulkInsertMode.OverwriteExisting);
-        }
+        public TitlePrincipalsRepository(IDocumentStore store) : base(store) {}
 
         public async Task<IReadOnlyList<TitlePrincipals>> FindByTitle(string tconst)
         {
@@ -123,6 +89,11 @@ namespace IMDb.Infrastructure.Repositories
                 .Skip(pagination.Skip)
                 .Take(pagination.Take)
                 .ToListAsync();
+        }
+
+        protected override string GetUrl()
+        {
+            return "https://datasets.imdbws.com/title.principals.tsv.gz";
         }
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleRatingsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleRatingsRepository.cs
@@ -9,7 +9,7 @@ namespace IMDb.Infrastructure.Repositories
 {
     public class TitleRatingsRepository : AbstractRepository<TitleRatings>, ITitleRatingsRepository
     {
-        public TitleRatingsRepository(IDocumentStore store) : base(store) {}
+        public TitleRatingsRepository(IDocumentStore store) : base(store) { }
 
         public async Task<TitleRatings> FindByTitle(string tconst)
         {
@@ -55,9 +55,6 @@ namespace IMDb.Infrastructure.Repositories
                 .ToListAsync();
         }
 
-        protected override string GetUrl()
-        {
-            return "https://datasets.imdbws.com/title.ratings.tsv.gz";
-        }
+        protected override string GetUrl() => "https://datasets.imdbws.com/title.ratings.tsv.gz";
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleRatingsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleRatingsRepository.cs
@@ -7,43 +7,9 @@ using Marten;
 
 namespace IMDb.Infrastructure.Repositories
 {
-    public class TitleRatingsRepository : ITitleRatingsRepository
+    public class TitleRatingsRepository : AbstractRepository<TitleRatings>, ITitleRatingsRepository
     {
-        private readonly IDocumentStore _store;
-
-        public TitleRatingsRepository(IDocumentStore store) => _store = store;
-
-        public async Task Add(TitleRatings model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Insert(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Update(TitleRatings model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Update(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public async Task Delete(TitleRatings model)
-        {
-            using var session = _store.DirtyTrackedSession();
-
-            session.Delete(model);
-
-            await session.SaveChangesAsync();
-        }
-
-        public void BulkSync(IEnumerable<TitleRatings> models)
-        {
-            _store.BulkInsert(models.ToArray(), BulkInsertMode.OverwriteExisting);
-        }
+        public TitleRatingsRepository(IDocumentStore store) : base(store) {}
 
         public async Task<TitleRatings> FindByTitle(string tconst)
         {
@@ -87,6 +53,11 @@ namespace IMDb.Infrastructure.Repositories
                 .Skip(pagination.Skip)
                 .Take(pagination.Take)
                 .ToListAsync();
+        }
+
+        protected override string GetUrl()
+        {
+            return "https://datasets.imdbws.com/title.ratings.tsv.gz";
         }
     }
 }

--- a/src/IMDb.Infrastructure/Repositories/TitleRatingsRepository.cs
+++ b/src/IMDb.Infrastructure/Repositories/TitleRatingsRepository.cs
@@ -54,7 +54,5 @@ namespace IMDb.Infrastructure.Repositories
                 .Take(pagination.Take)
                 .ToListAsync();
         }
-
-        protected override string GetUrl() => "https://datasets.imdbws.com/title.ratings.tsv.gz";
     }
 }


### PR DESCRIPTION
I refactored the repository interfaces to inherit from an IRepository, and also made the repository implementations inherit from an abstract implementation. I also pulled the repository urls from the importer and stored them in their respective repository implementations. Finally, the importer now has a single method that will download and import datasets with the given type and repository.

There weren't any tests so I can't confirm if everything functions as intended, but it does build.